### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to GitHub Actions workflows
- Fixes 3 CodeQL security alerts about missing workflow permissions
- Implements principle of least privilege for GITHUB_TOKEN

## Changes Made
- ✅ Added `permissions: contents: read` to `.github/workflows/test.yml`
- ✅ Added `permissions: contents: read` to `.github/workflows/pr-checks.yml`
- ✅ `deploy.yml` already had proper permissions configured

## Security Impact
- Resolves medium severity CodeQL alerts (#1, #2, #3)
- Restricts GITHUB_TOKEN to only read repository contents
- Prevents potential privilege escalation in workflows

## Test Plan
- [x] Workflows build and run successfully
- [x] No functional changes to existing behavior
- [x] CodeQL alerts should be resolved after merge